### PR TITLE
👷 Replace Repology with Alpine CDN datasource for package pins

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,12 @@
   "labels": ["dependencies", "no-stale"],
   "commitMessagePrefix": "⬆️",
   "commitMessageTopic": "{{depName}}",
+  "customDatasources": {
+    "alpine": {
+      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/",
+      "format": "html"
+    }
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -57,8 +63,9 @@
         "\\s\\s(?<package>[a-z0-9-_]+)=(?<currentValue>[a-z0-9-_.]+)\\s+"
       ],
       "versioningTemplate": "loose",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_24/{{package}}"
+      "datasourceTemplate": "custom.alpine",
+      "depNameTemplate": "alpine_3_24/{{package}}",
+      "extractVersionTemplate": "^{{{package}}}-(?<version>\\d.*)\\.apk$"
     }
   ],
   "packageRules": [
@@ -69,12 +76,12 @@
       "automerge": true
     },
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true
     },
     {
       "groupName": "OpenSSL",
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true,
       "matchPackageNames": ["/^alpine_.*/(libssl|libcrypto).*$/"]
     },


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Renovate's `repology` datasource has stopped resolving Alpine package pins across the org. Every `alpine_3_24/*` lookup returns `no-result`, so Alpine pins are no longer updated at all and builds break whenever upstream moves a pinned package. Repology rate limits its `tools/project-by` endpoint hard, and each run resolves every pin through it.

This replaces Repology with a custom datasource that reads the Alpine CDN directory listing directly:

- Adds a `custom.alpine` datasource pointing at `https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/` in `html` format, so every `href` in the listing (`bash-5.3.9-r1.apk`) becomes a version candidate.
- Switches the Alpine custom manager to `custom.alpine` and adds `extractVersionTemplate` to pull the version out of the `.apk` filename. The leading `\d` in the pattern is what keeps `musl` from matching `musl-utils-1.2.6-r2.apk`, and `libssl3` from matching `libssl3-dev-...`.
- Points both `repology` package rules (the blanket automerge rule and the OpenSSL group) at `custom.alpine`.

Unlike the equivalent change on `app-ssh`, no rule for the Alpine `community` repository is needed here. All 10 pins in `base/Dockerfile` (`bash`, `curl`, `jq`, `libcrypto3`, `libssl3`, `musl`, `musl-utils`, `tar`, `tzdata`, `xz`) were checked against the `main` and `community` APKINDEX files for `v3.24`, and every one of them lives in `main`. Custom datasources use `registryStrategy: "first"`, so should a `community` package ever get pinned here, it will need a `registryUrls` override rule at that point.

Verified locally with a Renovate dry run, since CI cannot prove anything here (the config change does not touch the Dockerfile, so buildx serves the `apk` layer from cache and no `apk add` runs):

- `renovate-config-validator` passes, both as a global config and via autodetection as the repository config.
- `LOG_LEVEL=debug RENOVATE_PLATFORM=local RENOVATE_DRY_RUN=lookup` resolves all **10 of 10** pins, matching the 10 pins in `base/Dockerfile` exactly. Lookup statistics report `"custom.alpine": {"count": 10}`, and every dep comes back with a populated `currentVersion`/`fixedVersion` and an empty `warnings` array.
- **Zero** `Found no results` lines and zero `ERROR`/`WARN` lines in the run. The whole set of pins costs a single HTTP request to the CDN (9 cache hits for the rest) instead of one Repology request per package.
- No updates were found, and that agrees with the `v3.24` `main` APKINDEX: every pin in this repo is already at the current upstream version. So there are no stale pins here, and nothing is currently blocked on one.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Applies the same fix as hassio-addons/app-ssh#1119.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated tracking of Alpine Linux package updates.
  * Enhanced version detection for Alpine and OpenSSL packages.
  * Continued support for automatic dependency updates when changes meet the configured criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->